### PR TITLE
Update versioning in ci.yaml

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -52,7 +52,7 @@ jobs:
       run: echo "TAG=$(git describe --tags --abbrev=0)" >> $GITHUB_ENV
 
     - name: Define version
-      run: echo "VERSION=$TAG-${{ github.ref_name }}-$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+      run: echo "VERSION=$TAG-${{ github.ref_name }}-$(git rev-parse --short HEAD)-$(date +%s)" >> $GITHUB_ENV
 
     - uses: mikefarah/yq@master
       with:


### PR DESCRIPTION
В попередньому ПР #37 пропустив додавання таймстемпу в Хелм-чарт